### PR TITLE
docs: fix images fail to load

### DIFF
--- a/70. Retrieval Augmented Generation(RAG).md
+++ b/70. Retrieval Augmented Generation(RAG).md
@@ -30,8 +30,7 @@ are trained on.
   - Document Index: The database of documents (e.g., Wikipedia).
   - Generator: Uses the input question and retrieved documents to generate the final answer.
   
-<img width="962" alt="image" src="https://gist.github.com/assets/47337188/16466198-d16a-4af0-ae6b-b2b8e6985400.jpg">
-
+![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/15691472-33eb-49df-8daa-ca8394c6e1bd)
 
 _*Parametric Memory_: Knowledge stored within the model’s parameters.
 
@@ -60,7 +59,7 @@ Use cases:
 
 ## Example RAG Application
 
-<img width="798" alt="image" src="https://gist.github.com/assets/47337188/a0ed8b38-2b79-4073-8bb6-ef8e9eab6143.jpg">
+![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/5bb0bf9b-8aef-42f2-b8cc-7a59ccc5352a)
 
 RAG applications require a pipeline and a chain component to perform the following:
 
@@ -71,7 +70,7 @@ index, then passes the data, along with the query, to the LLM model.
 The following describes the details of the RAG chain in the context of an unstructured data RAG example.
 
 
-![image](https://gist.github.com/assets/47337188/dbb349f8-f30b-49e5-9a02-e2efe8fa10a3.jpg)
+![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/45e851ee-f80b-4b06-aa7a-7ad331878fe6)
 
 
 1. Embed the request using the same _embedding model*_ that was used to embed the data in the knowledge base.
@@ -84,9 +83,9 @@ LLM generate an appropriate response. Often, the LLM has a template for how to f
 
 _*Vector Database_: A vector database indexes and stores vector embeddings for fast retrieval and similarity search.
 
-<img width="981" alt="image" src="https://gist.github.com/assets/47337188/8c91df7d-2d62-4a9c-be02-fc495a9cc069.jpg">
+![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/1c42e7b1-fa0f-4598-a854-ecbcf9a7de9b)
 
-<img width="948" alt="image" src="https://gist.github.com/assets/47337188/26c049f2-9bf6-4890-8cbf-9da776a2b598.jpg">
+![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/95704f74-58ed-439b-acc2-31ccf83ad848)
 
 _*embedding model_:
 When both the question and the documentation are embedded using the same model, they are represented in the same 


### PR DESCRIPTION
Thanks for sharing! This pull request just fix the images. Right now, they're not loading because of an issue with the Content Security Policy which can be seen in the browser console:

> Refused to load the image '<URL>' because it violates the following Content Security Policy directive: "img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com".

![image](https://github.com/xinrong-meng/knowledge-sharing/assets/3375461/981a71a9-bd14-4c13-8b5d-9ee32ef25fb3)

This change will allow images to be displayed. You can preview it [here](https://github.com/hongbo-miao/knowledge-sharing/blob/docs/70.%20Retrieval%20Augmented%20Generation(RAG).md).

One solution is to upload your image at https://github.com/xinrong-meng/knowledge-sharing/issues/new and include the link. This way, the images will show up correctly. ☺️